### PR TITLE
feat: add pnpm & yarn 2+ support

### DIFF
--- a/src/commands/create/cli.ts
+++ b/src/commands/create/cli.ts
@@ -1,3 +1,5 @@
+import { execSync } from 'child_process';
+
 import prompts from 'prompts';
 import { unflatten } from 'flat';
 
@@ -5,7 +7,7 @@ import {
   adapterOptions, packageManagerOptions, pluginOptions, databaseDriversForAdapter, environmentVariablesPrompts,
 } from './options.js';
 import { CreateCommand } from './command.js';
-import { CreateCommandInput } from './types.js';
+import { CreateCommandInput, PackageManager } from './types.js';
 
 const questions: prompts.PromptObject[] = [
   {
@@ -31,6 +33,18 @@ const questions: prompts.PromptObject[] = [
     name: 'packageManager',
     message: 'Select a package manager',
     choices: packageManagerOptions,
+  },
+  {
+    type: (prev) => {
+      if (prev !== PackageManager.Yarn) {
+        return null;
+      }
+      const isYarn1 = execSync('yarn --version', { stdio: 'pipe' }).toString().trim().startsWith('1');
+      return isYarn1 ? null : 'confirm';
+    },
+    name: 'yarnPnp',
+    message: 'Would you like to enable Yarn PnP?',
+    initial: false,
   },
   {
     type: 'select',

--- a/src/commands/create/handlers/BaseSetup.handler.ts
+++ b/src/commands/create/handlers/BaseSetup.handler.ts
@@ -17,6 +17,9 @@ export class BaseSetupHandler extends BaseCommandHandler<CreateCommandInput> {
     await this.modifyPackageName();
     await this.copyDotFile('.eslintrc.cjs');
     await this.copyDotFile('.prettierrc');
+    if (this.options.packageManager === 'yarn') {
+      await this.setupYarnrc(!!this.options.yarnPnp);
+    }
     logger.info('Base template setup successful.');
   }
 
@@ -51,5 +54,11 @@ export class BaseSetupHandler extends BaseCommandHandler<CreateCommandInput> {
       entry,
       destination,
     );
+  }
+
+  protected async setupYarnrc(pnpEnabled: boolean) {
+    const yarnrcPath = path.join(process.cwd(), this.options.projectName, '.yarnrc.yml');
+    const content = `nodeLinker: ${pnpEnabled ? 'pnp' : 'node-modules'}\n`;
+    await fs.writeFile(yarnrcPath, content, 'utf8');
   }
 }

--- a/src/commands/create/handlers/BaseSetup.handler.ts
+++ b/src/commands/create/handlers/BaseSetup.handler.ts
@@ -58,7 +58,18 @@ export class BaseSetupHandler extends BaseCommandHandler<CreateCommandInput> {
 
   protected async setupYarnrc(pnpEnabled: boolean) {
     const yarnrcPath = path.join(process.cwd(), this.options.projectName, '.yarnrc.yml');
-    const content = `nodeLinker: ${pnpEnabled ? 'pnp' : 'node-modules'}\n`;
+    let content = pnpEnabled ? 'nodeLinker: pnp' : 'nodeLinker: node-modules';
+
+    // An workaround for dependencies problem
+    // Ref: https://github.com/ueberdosis/tiptap/issues/3746
+    if (pnpEnabled) {
+      content += `
+packageExtensions:
+  '@tiptap/starter-kit@^2.0.0':
+    peerDependencies:
+      '@tiptap/pm': '^2.0.0'`;
+    }
+
     await fs.writeFile(yarnrcPath, content, 'utf8');
   }
 }

--- a/src/commands/create/options.ts
+++ b/src/commands/create/options.ts
@@ -7,6 +7,7 @@ import {
 export const packageManagerOptions = [
   { title: 'NPM', value: PackageManager.NPM },
   { title: 'Yarn', value: PackageManager.Yarn },
+  { title: 'PNPM', value: PackageManager.PNPM },
 ];
 
 export const pluginOptions = [

--- a/src/commands/create/types.ts
+++ b/src/commands/create/types.ts
@@ -19,6 +19,7 @@ export enum AdminJSPlugin {
 export enum PackageManager {
   NPM = 'npm',
   Yarn = 'yarn',
+  PNPM = 'pnpm',
 }
 
 export enum DatabaseDriver {
@@ -37,6 +38,7 @@ export interface CreateCommandInput {
   adapter: AdminJSAdapter;
   plugin: AdminJSPlugin;
   packageManager: PackageManager;
+  yarnPnp?: boolean;
   databaseDriver?: DatabaseDriver;
   env?: {
     DATABASE_URL: string;


### PR DESCRIPTION
It's been about 3 years from the release of yarn 3 but adminjs-cli still doesn't work well with pnp mode.
It appears that pnp mode is now quite commonly used, So I've added yarnrc.yml and a selection for pnpm.

Specifically, there's a notable problem with tiptap packages that adminjs-design-system depends on. (It is also reproducible on pnp mode)
I hope tiptap maintainer addresses this soon but it doesn't seem very likely. That's why I added a workaround. I hope this helps.

Ref. https://github.com/ueberdosis/tiptap/issues/3746